### PR TITLE
Ars Nouveau Integration Recipe

### DIFF
--- a/src/main/resources/data/opalescence/recipe/mod_integration/ars_nouveau/budding_conversion/budding_opal.json
+++ b/src/main/resources/data/opalescence/recipe/mod_integration/ars_nouveau/budding_conversion/budding_opal.json
@@ -1,0 +1,11 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "ars_nouveau"
+    }
+  ],
+  "type": "ars_nouveau:budding_conversion",
+  "input": "opalescence:opal",
+  "result": "opalescence:budding_opal"
+}


### PR DESCRIPTION
This recipe allows players to employ their Amethyst Golems to create Budding Opal Blocks out of Opal Blocks.