### PR TITLE
Ars Nouveau Integration Tags

### DIFF
--- a/src/main/resources/data/ars_nouveau/tags/block/golem/budding.json
+++ b/src/main/resources/data/ars_nouveau/tags/block/golem/budding.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "opalescence:budding_opal"
+  ]
+}

--- a/src/main/resources/data/ars_nouveau/tags/block/golem/cluster.json
+++ b/src/main/resources/data/ars_nouveau/tags/block/golem/cluster.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "opalescence:opal_crystal_cluster"
+  ]
+}


### PR DESCRIPTION
Nescessary Tags to allow Amethyst Golems interacting with Budding Opal Blocks and collection of Opal Crystals from fully grown Opal Clusters.