### PR TITLE
Adding Integration with Ars Nouveau

### DIFF
--- a/src/main/resources/data/ars_nouveau/tags/block/golem/budding.json
+++ b/src/main/resources/data/ars_nouveau/tags/block/golem/budding.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "opalescence:budding_opal"
+  ]
+}

--- a/src/main/resources/data/ars_nouveau/tags/block/golem/cluster.json
+++ b/src/main/resources/data/ars_nouveau/tags/block/golem/cluster.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "opalescence:opal_crystal_cluster"
+  ]
+}

--- a/src/main/resources/data/opalescence/recipe/mod_integration/ars_nouveau/budding_conversion/budding_opal.json
+++ b/src/main/resources/data/opalescence/recipe/mod_integration/ars_nouveau/budding_conversion/budding_opal.json
@@ -1,0 +1,11 @@
+{
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:mod_loaded",
+      "modid": "ars_nouveau"
+    }
+  ],
+  "type": "ars_nouveau:budding_conversion",
+  "input": "opalescence:opal",
+  "result": "opalescence:budding_opal"
+}


### PR DESCRIPTION
This integration will allow Amethyst Golems to convert Opal Blocks into Budding Opal Blocks, as well as collect fully grown Opal Clusters.
This does not touch other variants of Opal Clusters as of now, however that's mostly because:
1. I completely forgot about them at the time while I was figuring out the forks and pull requests and everything here on Github... this took me HOURS to figure out for what should be at most 10 minutes for others
2. Other variants take incredibly long time for convesion to finish before golem can easily harvest fully grown Clusters.
I tried getting few Unpleasant Clusters to fully convert and it takes a quite a bit of time for some to convert *on tick sprinting*.
Golem will snap them as regular Clusters before they convert.
I also tested Moonlit Opal Clusters and they took similar amount of time to get in the right conditions.
Even without Golems automatically harvesting the other clusters, they should still make farming Opal blocks a lot easier.

Feel free to add more clusters if you want to the tags.